### PR TITLE
Refactor SongScores

### DIFF
--- a/devolving_music/views/current_playlist.py
+++ b/devolving_music/views/current_playlist.py
@@ -11,5 +11,5 @@ class CurrentPlaylist(LoginRequiredMixin, View):
     def get(self, _request, event: Event):
         return success([
             score.to_json()
-            for score in SongScores(event).get_final_list()
+            for score in SongScores.all_from_event(event).get_final_list().scores_list
         ])

--- a/devolving_music/views/score_suites.py
+++ b/devolving_music/views/score_suites.py
@@ -11,5 +11,5 @@ class ScoreSuitesView(LoginRequiredMixin, View):
     def get(self, _request, event: Event):
         return success([
             score_suite.to_json()
-            for score_suite in SongScores(event).scores_list
+            for score_suite in SongScores.all_from_event(event).scores_list
         ])


### PR DESCRIPTION
I initially set out to write the quality filtering logic, but I found the `SongScores` API to be a bit unpredictable to work with. The main goal of this PR is to make it easier and safer to use `SongScores`, by doing the following:

- Because score calculation only needs to happen once during an initialization phase, I judged it safer to pull it into `ScoreSuite`.
- Unifying confusing type patterns. For example, making `get_compare_submission_random` and `get_compare_submission_closest` have the same return type and similar argument signatures. But most importantly,
  - I made `list[ScoreSuite]` the primary data type on which `SongScore` logic operates.
    - Once score calculation was pulled into a single initialization step outside the `SongScores` class, the uses of the score dictionary were few and didn't necessarily need to use a dictionary.
    - Sorting and ordering is a pretty core concern when dealing with `ScoreSuite`s.
- Making `SongScores` function more like an ORM query, that can chain transformations.
- General cleanup and code quality improvements, including some unaddressed comments from previous PRs.
  - Removed unused methods `get_compare_submission_linear` and `get_dict_from_keys`.